### PR TITLE
Support SPDX 3 identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ assert(satisfies('GPL-3.0', 'GPL-2.0+'))
 assert(satisfies('GPL-1.0+', 'GPL-2.0+'))
 assert(!satisfies('GPL-1.0', 'GPL-2.0+'))
 assert(satisfies('GPL-2.0-only', 'GPL-2.0-only'))
+assert(satisfies('GPL-3.0-only', 'GPL-2.0+'))
 
 assert(!satisfies(
   'GPL-2.0',

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "3.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
-    "spdx-compare": "^0.1.2",
+    "spdx-compare": "^1.0.0",
     "spdx-expression-parse": "^3.0.0",
-    "spdx-ranges": "^1.0.1"
+    "spdx-ranges": "^2.0.0"
   },
   "devDependencies": {
     "defence-cli": "^2.0.1",


### PR DESCRIPTION
cc @jinwoo @goneall

The crux of this PR is version bumps of spdx-compare and spdx-compare, as well as a preprocessing normalization that converts `GPL-2.0-only` to `GPL-2.0`, `GPL-2.0-or-later` to `GPL-2.0+`, and so on.