### PR TITLE
Fix AND matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ assert(satisfies(
 ))
 
 assert(satisfies('(MIT OR GPL-2.0)', '(ISC OR MIT)'))
+assert(satisfies('(MIT AND GPL-2.0)', '(MIT AND GPL-2.0)'))
+assert(satisfies('MIT AND GPL-2.0 AND ISC', 'MIT AND GPL-2.0 AND ISC'))
+assert(satisfies('(MIT OR GPL-2.0) AND ISC', 'MIT AND ISC'))
+assert(satisfies('MIT AND ISC', '(MIT OR GPL-2.0) AND ISC'))
+assert(satisfies('(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)', 'Apache-2.0 AND ISC'))
+assert(satisfies('(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)', 'Apache-2.0 OR ISC'))
 assert(satisfies('(MIT AND GPL-2.0)', '(MIT OR GPL-2.0)'))
+assert(satisfies('(MIT AND GPL-2.0)', '(GPL-2.0 AND MIT)'))
 assert(!satisfies('(MIT AND GPL-2.0)', '(ISC OR GPL-2.0)'))
+assert(!satisfies('MIT AND (GPL-2.0 OR ISC)', 'MIT'))
+assert(!satisfies('(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)', 'MIT'))
 ```

--- a/index.js
+++ b/index.js
@@ -60,7 +60,14 @@ var licensesAreCompatible = function (first, second) {
 
 var recurseLeftAndRight = function (first, second) {
   var firstConjunction = first.conjunction
-  if (firstConjunction === 'and') {
+  var secondConjunction = second.conjunction
+
+  if (firstConjunction === 'and' && secondConjunction === 'and') {
+    return (
+      (recurse(first.left, second.left) && recurse(first.right, second.right)) ||
+      (recurse(first.left, second.right) && recurse(first.right, second.left))
+    )
+  } else if (firstConjunction === 'and') {
     return (
       recurse(first.left, second) &&
       recurse(first.right, second)


### PR DESCRIPTION
I found that `satisfies()` was returning false for 

```js
satisfies('MIT AND Apache-2.0', 'MIT AND Apache-2.0')
```

This code checks if both sides are ands and then recurses both conjunctions
Also adds some tests to the readme to cover these cases.