### PR TITLE
Accept an AST and a whitelist Array of AST leaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,11 @@ assert(!satisfies(
   },
   [{license: 'MIT'}]
 ))
+```
 
+The exported function does a few naive type checks on arguments.  Do not rely on it for rigorous validation.
+
+```javascript
 assert.throws(function () {
   satisfies('MIT', [parse('MIT')])
 }, /first argument/)

--- a/README.md
+++ b/README.md
@@ -192,4 +192,24 @@ assert(!satisfies(
   },
   [{license: 'MIT'}]
 ))
+
+assert.throws(function () {
+  satisfies('MIT', [parse('MIT')])
+}, /first argument/)
+
+assert.throws(function () {
+  satisfies({invalid: 'AST'}, [parse('MIT')])
+}, /first argument/)
+
+assert.throws(function () {
+  satisfies(parse('MIT'), parse('MIT'))
+}, /second argument/)
+
+assert.throws(function () {
+  satisfies(parse('MIT'), parse('MIT'))
+}, /second argument/)
+
+assert.throws(function () {
+  satisfies(parse('MIT'), [{invalid: 'leaf'}])
+}, /second argument/)
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 var compare = require('spdx-compare')
-var parse = require('spdx-expression-parse')
 var ranges = require('spdx-ranges')
+
+module.exports = function (first, second) {
+  var terms = normalizeGPLIdentifiers(first)
+  var whitelist = second.map(function (element) {
+    return normalizeGPLIdentifiers(element)
+  })
+  return recurse(terms, whitelist)
+}
 
 var rangesAreCompatible = function (first, second) {
   return (
@@ -79,60 +86,17 @@ function endsWith (string, substring) {
   return string.indexOf(substring) === string.length - 1
 }
 
-function licenseString (e) {
-  if (e.hasOwnProperty('noassertion')) return 'NOASSERTION'
-  if (e.license) return `${e.license}${e.plus ? '+' : ''}${e.exception ? ` WITH ${e.exception}` : ''}`
-}
-
-// Expand the given expression into an equivalent array where each member is an array of licenses AND'd
-// together and the members are OR'd together. For example, `(MIT OR ISC) AND GPL-3.0` expands to
-// `[[GPL-3.0 AND MIT], [ISC AND MIT]]`. Note that within each array of licenses, the entries are
-// normalized (sorted) by license name.
-function expand (expression) {
-  return sort(Array.from(expandInner(expression)))
-}
-
-// Flatten the given expression into an array of all licenses mentioned in the expression.
-function flatten (expression) {
-  const expanded = Array.from(expandInner(expression))
-  const flattened = expanded.reduce(function (result, clause) {
-    return Object.assign(result, clause)
-  }, {})
-  return sort([flattened])[0]
-}
-
-function expandInner (expression) {
-  if (!expression.conjunction) return [{ [licenseString(expression)]: expression }]
-  if (expression.conjunction === 'or') return expandInner(expression.left).concat(expandInner(expression.right))
-  if (expression.conjunction === 'and') {
-    var left = expandInner(expression.left)
-    var right = expandInner(expression.right)
-    return left.reduce(function (result, l) {
-      right.forEach(function (r) { result.push(Object.assign({}, l, r)) })
-      return result
-    }, [])
+function recurse (terms, whitelist) {
+  var conjunction = terms.conjunction
+  if (!conjunction) {
+    return whitelist.some(function (whitelisted) {
+      return licensesAreCompatible(terms, whitelisted)
+    })
+  } else if (conjunction === 'or') {
+    return recurse(terms.left, whitelist) || recurse(terms.right, whitelist)
+  } else if (conjunction === 'and') {
+    return recurse(terms.left, whitelist) && recurse(terms.right, whitelist)
+  } else {
+    throw new Error('invalid terms')
   }
 }
-
-function sort (licenseList) {
-  var sortedLicenseLists = licenseList
-    .filter(function (e) { return Object.keys(e).length })
-    .map(function (e) { return Object.keys(e).sort() })
-  return sortedLicenseLists.map(function (list, i) {
-    return list.map(function (license) { return licenseList[i][license] })
-  })
-}
-
-function isANDCompatible (one, two) {
-  return one.every(function (o) {
-    return two.some(function (t) { return licensesAreCompatible(o, t) })
-  })
-}
-
-function satisfies (first, second) {
-  var one = expand(normalizeGPLIdentifiers(parse(first)))
-  var two = flatten(normalizeGPLIdentifiers(parse(second)))
-  return one.some(function (o) { return isANDCompatible(o, two) })
-}
-
-module.exports = satisfies

--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@ var compare = require('spdx-compare')
 var ranges = require('spdx-ranges')
 
 module.exports = function (first, second) {
+  if (!Array.isArray(second)) throw new Error('second argument must be an Array')
+  if (second.some(function (element) {
+    return !element.hasOwnProperty('license')
+  })) throw new Error('second argument must contain license expression AST leaves')
+  if (
+    !first.hasOwnProperty('license') &&
+    !first.hasOwnProperty('conjunction')
+  ) throw new Error('first argument must be a license expression AST')
   var terms = normalizeGPLIdentifiers(first)
   var whitelist = second.map(function (element) {
     return normalizeGPLIdentifiers(element)

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   ],
   "dependencies": {
     "spdx-compare": "^1.0.0",
-    "spdx-expression-parse": "^3.0.0",
     "spdx-ranges": "^2.0.0"
   },
   "devDependencies": {
     "defence-cli": "^2.0.1",
     "replace-require-self": "^1.1.1",
+    "spdx-expression-parse": "^3.0.0",
     "standard": "^11.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Taking off from: https://github.com/jslicense/spdx-satisfies.js/pull/7#issuecomment-476014048

This PR redesigns the external API to take new kinds of arguments:

1. the AST for an SPDX expression, in the form returned by [spdx-expression-parse](https://www.npmjs.com/package/spdx-expression-parse)

2. an Array of AST leaves, each corresponding to a license, license with exception, license range, or license range with exception

A few benefits:

- This approach massively simplifies the underlying algorithm.  We're back to straightforward recursion.

- This approach leaves room for nonstandard license identifiers. `spdx-expression-parse` is now a `devDependency`, for the test suite.  But neither the parser nor the license-list data package it depends on remain production dependencies.

- Completely valid and completely unanswerable questions about the intended semantics are entirely avoided. Which is a good sign.