### PR TITLE
Refactor/compare complex expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function anyExpressionCompatible (one, two) {
 /**
  * Check if "first" satisfies "second".
  * @param {string} first - A valid SPDX expression.
- * @param {string|[]} second - A string with a SPDX expression or a list of licenses.
+ * @param {string|string[]} second - A string with a SPDX expression or a list of licenses.
  * @return {boolean} - Whether "first" satisfies "second".
  */
 function satisfies (first, second) {

--- a/index.js
+++ b/index.js
@@ -146,12 +146,19 @@ function anyExpressionCompatible (one, two) {
 /**
  * Check if "first" satisfies "second".
  * @param {string} first - A valid SPDX expression.
- * @param {string} second - A valid SPDX expression to be checked against.
+ * @param {string|[]} second - A string with a SPDX expression or a list of licenses.
  * @return {boolean} - Whether "first" satisfies "second".
  */
 function satisfies (first, second) {
   var one = expand(normalizeGPLIdentifiers(parse(first)))
-  var two = expand(normalizeGPLIdentifiers(parse(second)))
+  var two
+  if (Array.isArray(second)) {
+    two = second.map(l => normalizeGPLIdentifiers(parse(l)))
+    if (two.some(l => !!l.conjunction)) throw new Error('AND and OR operator are not allowed')
+    two = two.map(l => [l])
+  } else {
+    two = expand(normalizeGPLIdentifiers(parse(second)))
+  }
   return anyExpressionCompatible(one, two)
 }
 


### PR DESCRIPTION
## Description
This change focuses on two aspects:

- Addressing the current issue when comparing two SPDX expressions
- Allowing the use of an array of licenses as the `second` argument, following this [comment](https://github.com/jslicense/spdx-satisfies.js/issues/14#issuecomment-1546924220) and based on this [change](https://github.com/jslicense/spdx-satisfies.js/pull/17).

Our main goal is to make both approaches compatible, so users can decide whether to compare SPDX expressions or an allowed list of licenses.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jslicense/spdx-satisfies.js/issues/14

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The main problem right now is that the library doesn't function properly when comparing certain SPDX expressions, such as `satisfies("MIT", "MIT AND Apache-2.0")`. In this case, the function should return `false`.

With the following example `MIT AND Apache-2.0 OR GPL-1.0+`, the `expand` function returns the following:

```js
[
  ["MIT", "Apache-2.0"],
  ["GPL-1.0+"]
]
```

This implies that the elements in the outer array are alternatives based on the `OR` operator. The licenses in the inner arrays are grouped based on the `AND` operator. If `second` were `MIT OR GPL-2.0`, the result would be:

```js
[
  ["MIT"],
  ["GPL-2.0"]
]
```

In our opinion, the algorithm should check if there's any inner element within the outer array of `first` that is satisfied by any inner element of `second`.

When comparing `["MIT", "Apache-2.0"]` and `["MIT"]`, the result is negative. Similarly, when comparing `["MIT", "Apache-2.0"]` and `["GPL-2.0"]`, as well as `["GPL-1.0+"]` and `["MIT"]`, the result is again negative. However, when comparing `["GPL-1.0+"]` and `["GPL-2.0"]`, the result is positive since `first` should be `MIT AND Apache-2.0` **`OR`** `GPL-1.0+`, which we understand is correct.

On the other hand, we believe that the suggestion mentioned in this [comment](https://github.com/jslicense/spdx-satisfies.js/issues/14#issuecomment-1546924220) and this [change](https://github.com/jslicense/spdx-satisfies.js/pull/17) can be compatible with `second` as an SPDX expression. This way, backwards compatibility is ensured because there may be users who expect to use `satisfies` with two expressions, while other users expect `second` as an `allowList`.

We have interpreted that the licenses in `second` would be alternatives that `first` should comply with. So the following usages would be equivalent:

```js
satisfies("MIT", "MIT OR Apache-2.0")
satisfies("MIT", ["MIT", "Apache-2.0"])
```
In the event that the interpretation of `second` as an `allowList` implies that the licenses are not alternatives but requirements that `first` must fulfill, the PR would need a slight modification. In that case, the following examples would be equivalent:

```js
satisfies("MIT", "MIT AND Apache-2.0")
satisfies("MIT", ["MIT", "Apache-2.0"])
```
@kemitchell please, let us know which of the above approaches you have in mind. Thanks

cc/ @inigomarquinez @nanotower